### PR TITLE
Revert logging technique back to netstandard2 approach

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# Matrix.Example.Client uses spaces
+# Matrix.Tests omitted as I don't know how to specify multiple targets here
+[Matrix/*.cs]
+curly_bracket_next_line = true
+indent_style = tab
+indent_size = 4

--- a/Matrix.Tests/Backend/TestingAPIBackend.cs
+++ b/Matrix.Tests/Backend/TestingAPIBackend.cs
@@ -11,6 +11,10 @@ namespace Matrix.Backends
             return null;
         }
 
+		public Task<MatrixAPIResult> GetAsync(string apiPath, bool authenticate) {
+  			return null;
+		}
+
 		public MatrixRequestError Post (string apiPath, bool authenticate, JToken request, out JToken result) {
             result = null;
             return null;

--- a/Matrix/Client/Keys.cs
+++ b/Matrix/Client/Keys.cs
@@ -1,0 +1,13 @@
+﻿#define KLUDGE
+
+using System;
+
+namespace Matrix.Client
+{
+#if KLUDGE
+    public class Keys
+    {
+        public Keys(MatrixAPI api) { }
+    }
+#endif
+}

--- a/Matrix/Client/MatrixClient.cs
+++ b/Matrix/Client/MatrixClient.cs
@@ -75,6 +75,7 @@ namespace Matrix.Client
         /// Initializes a new instance of the <see cref="Matrix.Client.MatrixClient"/> class for testing.
         /// </summary>
         public MatrixClient (MatrixAPI api){
+            log.LogDebug("ctor: baseurl={}", api.BaseURL);
             this.Api = api;
             api.SyncJoinEvent += MatrixClient_OnEvent;
             api.SyncInviteEvent += MatrixClient_OnInvite;

--- a/Matrix/Logger.cs
+++ b/Matrix/Logger.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
 
 namespace Matrix
 {
@@ -10,7 +12,20 @@ namespace Matrix
         /// Needs to be externally set, one typical use case would be it's set during Startup configuration
         /// </summary>
 		public static ILoggerFactory Factory {
-			get { return factory ?? new LoggerFactory(); }
+			get 
+			{
+				// Stuffing in a console logger in a 2.1+ compatible way looks
+				// like a lot of work if you aren't using IServiceCollection
+#if NETSTANDARD2_0
+				if (factory == null)
+					// Call may not be present in .NET Standard 2.1
+					factory = new LoggerFactory().AddConsole(LogLevel.Debug);
+#endif
+				// NOTE: Might not be performant always creating empty factories,
+				// but want to give code opportunity to eventually log somehow
+				// (i.e. you really are expected to assign Factory)
+				return factory ?? new LoggerFactory(); 
+			}
             set { factory = value; }
         }
     }

--- a/Matrix/Logger.cs
+++ b/Matrix/Logger.cs
@@ -4,9 +4,15 @@ namespace Matrix
 {
     public static class Logger
     {
-        public static ILoggerFactory Factory = LoggerFactory.Create(builder =>
+        static ILoggerFactory factory;
+
+        /// <summary>
+        /// Needs to be externally set, one typical use case would be it's set during Startup configuration
+        /// </summary>
+        public static ILoggerFactory Factory
         {
-            
-        });
+            get { return factory ?? new LoggerFactory(); }
+            set { factory = value; }
+        }
     }
 }

--- a/Matrix/Logger.cs
+++ b/Matrix/Logger.cs
@@ -9,9 +9,8 @@ namespace Matrix
         /// <summary>
         /// Needs to be externally set, one typical use case would be it's set during Startup configuration
         /// </summary>
-        public static ILoggerFactory Factory
-        {
-            get { return factory ?? new LoggerFactory(); }
+		public static ILoggerFactory Factory {
+			get { return factory ?? new LoggerFactory(); }
             set { factory = value; }
         }
     }

--- a/Matrix/Matrix.csproj
+++ b/Matrix/Matrix.csproj
@@ -14,16 +14,12 @@
     <PackageReleaseNotes>Initial package release.</PackageReleaseNotes>
     <Copyright>Copyright 2017</Copyright>
     <PackageTags>Matrix SDK</PackageTags>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0-preview.19074.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="YamlDotNet" Version="5.3.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="bin\**;obj\**;" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- "Builder" way of doing logger almost definitely better, but not ready for most of us yet.  This decouples us from .NET 3.0 preview requirement (addressing #7 )
- Also adding somewhat-helpful .editorconfig