### PR TITLE
Ability to initialize MatrixClient with a custom HttpClientHandler

### DIFF
--- a/Matrix/Backends/HttpBackend.cs
+++ b/Matrix/Backends/HttpBackend.cs
@@ -11,185 +11,208 @@ using Newtonsoft.Json.Linq;
 
 namespace Matrix.Backends
 {
-	public class HttpBackend : IMatrixAPIBackend
-	{
-		private string baseurl;
-		private string access_token;
-		private string user_id;
-		private HttpClient client;
+  public class HttpBackend : IMatrixAPIBackend
+  {
+    private string baseurl;
+    private string access_token;
+    private string user_id;
+    private HttpClient client;
 
-		public HttpBackend(string apiurl, string user_id = null, HttpClient client = null){
-			baseurl = apiurl;
-			if (baseurl.EndsWith ("/")) {
-				baseurl = baseurl.Substring (0, baseurl.Length - 1);
-			}
-			ServicePointManager.ServerCertificateValidationCallback += acceptCertificate;
-			this.client = client ?? new HttpClient();
-			this.user_id = user_id;
-		}
+    public HttpBackend(string apiurl, string user_id = null, HttpClient client = null)
+    {
+      baseurl = apiurl;
+      if (baseurl.EndsWith("/"))
+      {
+        baseurl = baseurl.Substring(0, baseurl.Length - 1);
+      }
+      ServicePointManager.ServerCertificateValidationCallback += acceptCertificate;
+      this.client = client ?? new HttpClient();
+      this.user_id = user_id;
+    }
 
-		private bool acceptCertificate (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors){
-			return true;//Find a better way to handle mono certs.
-		}
+    public HttpBackend(string apiurl, string user_id = null, HttpClientHandler handler = null)
+      : this(apiurl, user_id, new HttpClient(handler)) { }
 
-		public void SetAccessToken(string token){
-			access_token = token;
-		}
+    private bool acceptCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+    {
+      return true;//Find a better way to handle mono certs.
+    }
 
-		private string GetPath (string apiPath, bool auth)
-		{
-			apiPath = baseurl + apiPath;
-			if (auth) {
-				apiPath	+= (apiPath.Contains ("?") ? "&" : "?") + "access_token=" + access_token;
-				if (user_id != null) {
-					apiPath += "&user_id="+user_id;
-				}
-			}
-			return apiPath;
-		}
+    public void SetAccessToken(string token)
+    {
+      access_token = token;
+    }
 
-		private async Task <MatrixAPIResult> RequestWrap (Task<HttpResponseMessage> task)
-		{
-			var apiResult = new MatrixAPIResult();
-			try
-			{
-				Tuple<JToken, HttpStatusCode> res = await GenericRequest (task);
-				apiResult.result = res.Item1;
-				apiResult.error = new MatrixRequestError("", MatrixErrorCode.CL_NONE, res.Item2);
-			}
-			catch(MatrixServerError e)
-			{
-				int retryAfter = -1;
-				if (e.ErrorObject.ContainsKey("retry_after_ms"))
-				{
-					retryAfter = e.ErrorObject["retry_after_ms"].ToObject<int>();
-				}
-				apiResult.error = new MatrixRequestError(e.Message, e.ErrorCode, HttpStatusCode.InternalServerError, retryAfter);
-			}
-			return apiResult;
-		}
+    private string GetPath(string apiPath, bool auth)
+    {
+      apiPath = baseurl + apiPath;
+      if (auth)
+      {
+        apiPath += (apiPath.Contains("?") ? "&" : "?") + "access_token=" + access_token;
+        if (user_id != null)
+        {
+          apiPath += "&user_id=" + user_id;
+        }
+      }
+      return apiPath;
+    }
 
-		public MatrixRequestError Get (string apiPath, bool authenticate, out JToken result){
-			apiPath = GetPath (apiPath,authenticate);
-			Task<HttpResponseMessage> task = client.GetAsync (apiPath);
-			var res = RequestWrap(task);
-			res.Wait();
-			result = res.Result.result;
-			return res.Result.error;
-		}
-		
-		public Task<MatrixAPIResult> GetAsync(string apiPath, bool authenticate)
-		{
-			Task<HttpResponseMessage> task = client.GetAsync (GetPath (apiPath,authenticate));
-			return RequestWrap(task);
-		}
-		
-		public MatrixRequestError Delete (string apiPath, bool authenticate, out JToken result){
-			apiPath = GetPath (apiPath,authenticate);
-			Task<HttpResponseMessage> task = client.DeleteAsync(apiPath);
-			var res = RequestWrap(task);
-			res.Wait();
-			result = res.Result.result;
-			return res.Result.error;
-		}
+    private async Task<MatrixAPIResult> RequestWrap(Task<HttpResponseMessage> task)
+    {
+      var apiResult = new MatrixAPIResult();
+      try
+      {
+        Tuple<JToken, HttpStatusCode> res = await GenericRequest(task);
+        apiResult.result = res.Item1;
+        apiResult.error = new MatrixRequestError("", MatrixErrorCode.CL_NONE, res.Item2);
+      }
+      catch (MatrixServerError e)
+      {
+        int retryAfter = -1;
+        if (e.ErrorObject.ContainsKey("retry_after_ms"))
+        {
+          retryAfter = e.ErrorObject["retry_after_ms"].ToObject<int>();
+        }
+        apiResult.error = new MatrixRequestError(e.Message, e.ErrorCode, HttpStatusCode.InternalServerError, retryAfter);
+      }
+      return apiResult;
+    }
 
-		public MatrixRequestError Put(string apiPath, bool authenticate, JToken data, out JToken result){
-			StringContent content = new StringContent (data.ToString(Formatting.None), Encoding.UTF8, "application/json");
-			apiPath = GetPath (apiPath,authenticate);
-			Task<HttpResponseMessage> task = client.PutAsync(apiPath,content);
-			var res = RequestWrap(task);
-			res.Wait();
-			result = res.Result.result;
-			return res.Result.error;
-		}
+    public MatrixRequestError Get(string apiPath, bool authenticate, out JToken result)
+    {
+      apiPath = GetPath(apiPath, authenticate);
+      Task<HttpResponseMessage> task = client.GetAsync(apiPath);
+      var res = RequestWrap(task);
+      res.Wait();
+      result = res.Result.result;
+      return res.Result.error;
+    }
 
-		public Task<MatrixAPIResult> PutAsync(string apiPath, bool authenticate, JToken request)
-		{
-			StringContent content = new StringContent (request.ToString(Formatting.None), Encoding.UTF8, "application/json");
-			apiPath = GetPath (apiPath,authenticate);
-			Task<HttpResponseMessage> task = client.PutAsync(apiPath,content);
-			return RequestWrap(task);
-		}
+    public Task<MatrixAPIResult> GetAsync(string apiPath, bool authenticate)
+    {
+      Task<HttpResponseMessage> task = client.GetAsync(GetPath(apiPath, authenticate));
+      return RequestWrap(task);
+    }
 
-		public MatrixRequestError Post(string apiPath, bool authenticate, JToken data, Dictionary<string,string> headers , out JToken result){
-			StringContent content;
-			if (data != null) {
-				content = new StringContent (data.ToString (), Encoding.UTF8, "application/json");
-			} else {
-				content = new StringContent ("{}");
-			}
+    public MatrixRequestError Delete(string apiPath, bool authenticate, out JToken result)
+    {
+      apiPath = GetPath(apiPath, authenticate);
+      Task<HttpResponseMessage> task = client.DeleteAsync(apiPath);
+      var res = RequestWrap(task);
+      res.Wait();
+      result = res.Result.result;
+      return res.Result.error;
+    }
 
-			foreach(KeyValuePair<string,string> header in headers){
-				content.Headers.Add(header.Key,header.Value);
-			}
+    public MatrixRequestError Put(string apiPath, bool authenticate, JToken data, out JToken result)
+    {
+      StringContent content = new StringContent(data.ToString(Formatting.None), Encoding.UTF8, "application/json");
+      apiPath = GetPath(apiPath, authenticate);
+      Task<HttpResponseMessage> task = client.PutAsync(apiPath, content);
+      var res = RequestWrap(task);
+      res.Wait();
+      result = res.Result.result;
+      return res.Result.error;
+    }
 
-			apiPath = GetPath (apiPath,authenticate);
-			Task<HttpResponseMessage> task = client.PostAsync(apiPath,content);
-			var res = RequestWrap(task);
-			res.Wait();
-			result = res.Result.result;
-			return res.Result.error;
-		}
+    public Task<MatrixAPIResult> PutAsync(string apiPath, bool authenticate, JToken request)
+    {
+      StringContent content = new StringContent(request.ToString(Formatting.None), Encoding.UTF8, "application/json");
+      apiPath = GetPath(apiPath, authenticate);
+      Task<HttpResponseMessage> task = client.PutAsync(apiPath, content);
+      return RequestWrap(task);
+    }
 
-		public MatrixRequestError Post(string apiPath, bool authenticate, byte[] data, Dictionary<string, string> headers,
-			out JToken result)
-		{
-			ByteArrayContent content;
-			if (data != null)
-			{
-				content = new ByteArrayContent(data);
-			}
-			else
-			{
-				content = new ByteArrayContent(new byte[0]);
-			}
+    public MatrixRequestError Post(string apiPath, bool authenticate, JToken data, Dictionary<string, string> headers, out JToken result)
+    {
+      StringContent content;
+      if (data != null)
+      {
+        content = new StringContent(data.ToString(), Encoding.UTF8, "application/json");
+      }
+      else
+      {
+        content = new StringContent("{}");
+      }
 
-			foreach (KeyValuePair<string, string> header in headers)
-			{
-				content.Headers.Add(header.Key, header.Value);
-			}
+      foreach (KeyValuePair<string, string> header in headers)
+      {
+        content.Headers.Add(header.Key, header.Value);
+      }
 
-			apiPath = GetPath(apiPath, authenticate);
-			Task<HttpResponseMessage> task = client.PostAsync(apiPath, content);
-			var res = RequestWrap(task);
-			res.Wait();
-			result = res.Result.result;
-			return res.Result.error;
-		}
+      apiPath = GetPath(apiPath, authenticate);
+      Task<HttpResponseMessage> task = client.PostAsync(apiPath, content);
+      var res = RequestWrap(task);
+      res.Wait();
+      result = res.Result.result;
+      return res.Result.error;
+    }
 
-		public MatrixRequestError Post(string apiPath, bool authenticate, JToken data, out JToken result){
-			return Post(apiPath,authenticate,data, new Dictionary<string,string>(),out result);
-		}
+    public MatrixRequestError Post(string apiPath, bool authenticate, byte[] data, Dictionary<string, string> headers,
+      out JToken result)
+    {
+      ByteArrayContent content;
+      if (data != null)
+      {
+        content = new ByteArrayContent(data);
+      }
+      else
+      {
+        content = new ByteArrayContent(new byte[0]);
+      }
 
-		private async Task<Tuple<JToken, HttpStatusCode>> GenericRequest(Task<HttpResponseMessage> task){
-			Task<string> stask = null;
-			JToken result = null;
-			HttpResponseMessage httpResult;
-			try
-			{
-				httpResult = await task;
-				if (httpResult.StatusCode.HasFlag(HttpStatusCode.OK) ){
-					stask = httpResult.Content.ReadAsStringAsync();
-				}
-				else
-				{
-					return new Tuple<JToken, HttpStatusCode>(null, httpResult.StatusCode);
-				}
-			}
-			catch(WebException e){
-				throw e;
-			}
-			catch(AggregateException e){
-				throw new MatrixException (e.InnerException.Message,e.InnerException);
-			}
+      foreach (KeyValuePair<string, string> header in headers)
+      {
+        content.Headers.Add(header.Key, header.Value);
+      }
 
-			string json = await stask;
-			result = JToken.Parse(json);
-			if (result.Type == JTokenType.Object && result ["errcode"] != null) {
-				throw new MatrixServerError (result ["errcode"].ToObject<string> (), result ["error"].ToObject<string> (), result as JObject);
-			}
-			return new Tuple<JToken, HttpStatusCode>(result, httpResult.StatusCode);
-		}
-	}
+      apiPath = GetPath(apiPath, authenticate);
+      Task<HttpResponseMessage> task = client.PostAsync(apiPath, content);
+      var res = RequestWrap(task);
+      res.Wait();
+      result = res.Result.result;
+      return res.Result.error;
+    }
+
+    public MatrixRequestError Post(string apiPath, bool authenticate, JToken data, out JToken result)
+    {
+      return Post(apiPath, authenticate, data, new Dictionary<string, string>(), out result);
+    }
+
+    private async Task<Tuple<JToken, HttpStatusCode>> GenericRequest(Task<HttpResponseMessage> task)
+    {
+      Task<string> stask = null;
+      JToken result = null;
+      HttpResponseMessage httpResult;
+      try
+      {
+        httpResult = await task;
+        if (httpResult.StatusCode.HasFlag(HttpStatusCode.OK))
+        {
+          stask = httpResult.Content.ReadAsStringAsync();
+        }
+        else
+        {
+          return new Tuple<JToken, HttpStatusCode>(null, httpResult.StatusCode);
+        }
+      }
+      catch (WebException e)
+      {
+        throw e;
+      }
+      catch (AggregateException e)
+      {
+        throw new MatrixException(e.InnerException.Message, e.InnerException);
+      }
+
+      string json = await stask;
+      result = JToken.Parse(json);
+      if (result.Type == JTokenType.Object && result["errcode"] != null)
+      {
+        throw new MatrixServerError(result["errcode"].ToObject<string>(), result["error"].ToObject<string>(), result as JObject);
+      }
+      return new Tuple<JToken, HttpStatusCode>(result, httpResult.StatusCode);
+    }
+  }
 }
 

--- a/Matrix/Client/MatrixClient.cs
+++ b/Matrix/Client/MatrixClient.cs
@@ -1,347 +1,378 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using Matrix.Structures;
 using Microsoft.Extensions.Logging;
 
 namespace Matrix.Client
 {
+  /// <summary>
+  /// The Matrix Client is a wrapper over the MatrixAPI object which provides a safe managed way
+  /// to interact with a Matrix Home Server.
+  /// </summary>
+  public class MatrixClient : IDisposable
+  {
+    private ILogger log = Logger.Factory.CreateLogger<MatrixClient>();
+
+    public delegate void MatrixInviteDelegate(string roomid, MatrixEventRoomInvited joined);
+
     /// <summary>
-    /// The Matrix Client is a wrapper over the MatrixAPI object which provides a safe managed way
-    /// to interact with a Matrix Home Server.
+    /// How long to poll for a Sync request before we retry.
     /// </summary>
-    public class MatrixClient : IDisposable
+    /// <value>The sync timeout in milliseconds.</value>
+    public int SyncTimeout
     {
-        private ILogger log = Logger.Factory.CreateLogger<MatrixClient>();
-
-        public delegate void MatrixInviteDelegate(string roomid, MatrixEventRoomInvited joined);
-
-        /// <summary>
-        /// How long to poll for a Sync request before we retry.
-        /// </summary>
-        /// <value>The sync timeout in milliseconds.</value>
-        public int SyncTimeout { get => Api.SyncTimeout;
-            set{ Api.SyncTimeout = value; } }
-
-        readonly ConcurrentDictionary<string,MatrixRoom> _rooms	= new ConcurrentDictionary<string,MatrixRoom>();
-
-        public event MatrixInviteDelegate OnInvite;
-
-        public string UserId => Api.UserId;
-
-        /// <summary>
-        /// Get the underlying API that MatrixClient wraps. Here be dragons 🐲.
-        /// </summary>
-        public MatrixAPI Api { get; }
-        
-        public Client.Keys Keys { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Matrix.Client.MatrixClient"/> class.
-        /// The client will preform a connection and try to retrieve version information.
-        /// If this fails, a MatrixUnsuccessfulConnection Exception will be thrown.
-        /// </summary>
-        /// <param name="URL">URL before /_matrix/</param>
-        public MatrixClient (string URL)
-        {
-            log.LogDebug($"Created new MatrixClient instance for {URL}");
-            Api = new MatrixAPI (URL);
-            Keys = new Client.Keys(Api);
-            try{
-                Api.ClientVersions ();
-                Api.SyncJoinEvent += MatrixClient_OnEvent;
-                Api.SyncInviteEvent += MatrixClient_OnInvite;
-            }
-            catch(MatrixException e){
-                throw new MatrixException("An exception occured while trying to connect",e);
-            }
-        }
-
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Matrix.Client.MatrixClient"/> class.
-        /// This intended for Application Services only who want to preform actions as another user.
-        /// Sync is not preformed.
-        /// </summary>
-        /// <param name="URL">URL before /_matrix/</param>
-        /// <param name="application_token">Application token for the AS.</param>
-        /// <param name="userid">Userid as the user you intend to go as.</param>
-        public MatrixClient (string URL, string application_token, string userid)
-        {
-            Api = new MatrixAPI (URL,application_token, userid);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Matrix.Client.MatrixClient"/> class for testing.
-        /// </summary>
-        public MatrixClient (MatrixAPI api){
-            this.Api = api;
-            api.SyncJoinEvent += MatrixClient_OnEvent;
-            api.SyncInviteEvent += MatrixClient_OnInvite;
-        }
-
-        /// <summary>
-        /// Gets the sync token from the API.
-        /// </summary>
-        /// <returns>The sync token.</returns>
-        public string GetSyncToken() {
-            return Api.GetSyncToken ();
-        }
-
-        /// <summary>
-        /// Gets the access token from the API.
-        /// </summary>
-        /// <returns>The access token.</returns>
-        public string GetAccessToken ()
-        {
-            return Api.GetAccessToken();
-        }
-
-        public MatrixLoginResponse GetCurrentLogin ()
-        {
-            return Api.GetCurrentLogin();
-        }
-
-        private void MatrixClient_OnInvite(string roomid, MatrixEventRoomInvited joined){
-            if(OnInvite != null){
-                OnInvite.Invoke(roomid,joined);
-            }
-        }
-
-        private void MatrixClient_OnEvent (string roomid, MatrixEventRoomJoined joined)
-        {
-            MatrixRoom mroom;
-            if (!_rooms.ContainsKey (roomid)) {
-                mroom = new MatrixRoom (Api, roomid);
-                _rooms.TryAdd (roomid, mroom);
-                //Update existing room
-            } else {
-                mroom = _rooms [roomid];
-            }
-            joined.state.events.ToList ().ForEach (x => {mroom.FeedEvent (x);});
-            joined.timeline.events.ToList ().ForEach (x => {mroom.FeedEvent (x);});
-            mroom.SetEphemeral(joined.ephemeral);
-        }
-
-        /// <summary>
-        /// Login with a given username and password.
-        /// Currently, this is the only login method the SDK supports.
-        /// </summary>
-        /// <param name="username">Username</param>
-        /// <param name="password">Password</param>
-        public MatrixLoginResponse LoginWithPassword(string username, string password, string device_id = null){
-            var result = Api.ClientLogin (new MatrixLoginPassword (username, password, device_id));
-            Api.SetLogin(result);
-            return result;
-        }
-
-        /// <param name="syncToken"> If you stored the sync token before, you can set it for the API here</param>
-        public void StartSync(string syncToken = "")
-        {
-            Api.SetSyncToken(syncToken);
-            Api.ClientSync ();
-            Api.StartSyncThreads ();
-        }
-
-        /// <summary>
-        /// Login with a given username and token.
-        /// This method will also start a sync with the server
-        /// Currently, this is the only login method the SDK supports.
-        /// </summary>
-        /// <param name="username">Username</param>
-        /// <param name="token">Access Token</param>
-        public void LoginWithToken (string username, string token)
-        {
-            Api.ClientLogin (new MatrixLoginToken (username, token));
-            Api.ClientSync ();
-            Api.StartSyncThreads ();
-        }
-
-        /// <summary>
-        /// Use existing login information when connecting to Matrix.
-        /// </summary>
-        /// <param name="user_id">Full Matrix user id.</param>
-        /// <param name="access_token">Access token.</param>
-        /// <param name="refresh_token">Refresh token.</param>
-        public void UseExistingToken (string user_id, string access_token)
-        {
-            Api.SetLogin(new MatrixLoginResponse
-            {
-                user_id = user_id,
-                access_token = access_token,
-                home_server = Api.BaseURL
-            });
-        }
-
-
-        /// <summary>
-        /// Get information about a user from the server.
-        /// </summary>
-        /// <returns>A MatrixUser object</returns>
-        /// <param name="userid">User ID</param>
-        public MatrixUser GetUser(string userid = null){
-            userid = userid == null ? Api.UserId : userid;
-            MatrixProfile profile = Api.ClientProfile (userid);
-            if (profile != null) {
-                return new MatrixUser (profile, userid);
-            }
-            return null;
-        }
-
-        public void SetDisplayName (string displayname)
-        {
-            Api.ClientSetDisplayName(Api.UserId, displayname);
-        }
-
-        public void SetAvatar (string avatar)
-        {
-            Api.ClientSetAvatar(Api.UserId, avatar);
-        }
-
-        /// <summary>
-        /// Get all the Rooms that the user has joined.
-        /// </summary>
-        /// <returns>Array of MatrixRooms</returns>
-        public MatrixRoom[] GetAllRooms(){
-            return _rooms.Values.ToArray ();
-        }
-
-        /// <summary>
-        /// Creates a new room with the specified details, or a blank one otherwise.
-        /// </summary>
-        /// <returns>A MatrixRoom object</returns>
-        /// <param name="roomdetails">Optional set of options to send to the server.</param>
-        public MatrixRoom CreateRoom(MatrixCreateRoom roomdetails = null){
-            string roomid = Api.ClientCreateRoom (roomdetails);
-            if (roomid != null) {
-                MatrixRoom room = JoinRoom(roomid);
-                return room;
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Alias for <see cref="Matrix.MatrixClient.CreateRoom"/> which lets you set common items before creation.
-        /// </summary>
-        /// <returns>A MatrixRoom object</returns>
-        /// <param name="name">The room name.</param>
-        /// <param name="alias">The primary alias</param>
-        /// <param name="topic">The room topic</param>
-        public MatrixRoom CreateRoom(string name, string alias = null,string topic = null){
-            MatrixCreateRoom room = new MatrixCreateRoom ();
-            room.name = name;
-            room.room_alias_name = alias;
-            room.topic = topic;
-            return CreateRoom (room);
-        }
-
-        /// <summary>
-        /// Join a matrix room. If the user has already joined this room, do nothing.
-        /// </summary>
-        /// <returns>The room.</returns>
-        /// <param name="roomid">roomid or alias</param>
-        public MatrixRoom JoinRoom(string roomid){//TODO: Maybe add a try method.
-            if (!_rooms.ContainsKey (roomid)) {//TODO: Check the status of the room too.
-                roomid = Api.ClientJoin (roomid);
-                if(roomid == null){
-                    return null;
-                }
-                MatrixRoom room = new MatrixRoom (Api, roomid);
-                _rooms.TryAdd (room.ID, room);
-            }
-            return _rooms [roomid];
-        }
-
-        public MatrixMediaFile UploadFile(string contentType,byte[] data){
-            string url = Api.MediaUpload(contentType,data);
-            return new MatrixMediaFile(Api,url,contentType);
-        }
-
-        /// <summary>
-        /// Return a joined room object by it's roomid.
-        /// </summary>
-        /// <returns>The room.</returns>
-        /// <param name="roomid">Roomid.</param>
-        public MatrixRoom GetRoom(string roomid) {//TODO: Maybe add a try method.
-            MatrixRoom room = null;
-            _rooms.TryGetValue(roomid,out room);
-            if (room == null)
-            {
-                log.LogInformation($"Don't have {roomid} synced, getting the room from /state");
-                // If we don't have the room, attempt to grab it's state.
-                var state = Api.GetRoomState(roomid);
-                room = new MatrixRoom(Api, roomid);
-                foreach (var matrixEvent in state)
-                {
-                    room.FeedEvent(matrixEvent);
-                }
-                _rooms.TryAdd(roomid, room);
-            }
-            return room;
-        }
-        /// <summary>
-        /// Get a room object by any of it's registered aliases.
-        /// </summary>
-        /// <returns>The room by alias.</returns>
-        /// <param name="alias">CanonicalAlias or any Alias</param>
-        public MatrixRoom GetRoomByAlias(string alias){
-            MatrixRoom room = _rooms.Values.FirstOrDefault( x => {
-                if(x.CanonicalAlias == alias){
-                    return true;
-                }
-
-                if(x.Aliases != null){
-                    return x.Aliases.Contains(alias);
-                }
-                return false;
-            });
-            if (room != default(MatrixRoom)) {
-                return room;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Add a new type of message to be decoded during sync operations.
-        /// </summary>
-        /// <param name="msgtype">msgtype.</param>
-        /// <param name="type">Type that inheritis MatrixMRoomMessage</param>
-        public void AddRoomMessageType (string msgtype, Type type)
-        {
-            Api.AddMessageType(msgtype, type);
-        }
-
-        /// <summary>
-        /// Add a new type of state event to be decoded during sync operations.
-        /// </summary>
-        /// <param name="msgtype">msgtype.</param>
-        /// <param name="type">Type that inheritis MatrixMRoomMessage</param>
-        public void AddStateEventType (string msgtype, Type type)
-        {
-            Api.AddEventType(msgtype, type);
-        }
-
-        public PublicRooms GetPublicRooms(int limit = 0, string since = "", string server = "")
-        {
-            return Api.PublicRooms(limit, since, server);
-        }
-
-        public void DeleteFromRoomDirectory(string alias)
-        {
-            Api.DeleteFromRoomDirectory(alias);
-        }
- 
-        /// <summary>
-        /// Releases all resource used by the <see cref="Matrix.Client.MatrixClient"/> object.
-        /// In addition, this will stop the sync thread.
-        /// </summary>
-        /// <remarks>Call <see cref="Dispose"/> when you are finished using the <see cref="Matrix.Client.MatrixClient"/>. The
-        /// <see cref="Dispose"/> method leaves the <see cref="Matrix.Client.MatrixClient"/> in an unusable state. After
-        /// calling <see cref="Dispose"/>, you must release all references to the <see cref="Matrix.Client.MatrixClient"/>
-        /// so the garbage collector can reclaim the memory that the <see cref="Matrix.Client.MatrixClient"/> was occupying.</remarks>
-        public void Dispose(){
-            Api.StopSyncThreads ();
-        }
+      get => Api.SyncTimeout;
+      set { Api.SyncTimeout = value; }
     }
+
+    readonly ConcurrentDictionary<string, MatrixRoom> _rooms = new ConcurrentDictionary<string, MatrixRoom>();
+
+    public event MatrixInviteDelegate OnInvite;
+
+    public string UserId => Api.UserId;
+
+    /// <summary>
+    /// Get the underlying API that MatrixClient wraps. Here be dragons 🐲.
+    /// </summary>
+    public MatrixAPI Api { get; }
+
+    public Client.Keys Keys { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Matrix.Client.MatrixClient"/> class.
+    /// The client will preform a connection and try to retrieve version information.
+    /// If this fails, a MatrixUnsuccessfulConnection Exception will be thrown.
+    /// </summary>
+    /// <param name="URL">URL before /_matrix/</param>
+    public MatrixClient(string URL, HttpClientHandler handler = null)
+    {
+      log.LogDebug($"Created new MatrixClient instance for {URL}");
+      Api = new MatrixAPI(URL, handler);
+      Keys = new Client.Keys(Api);
+      try
+      {
+        Api.ClientVersions();
+        Api.SyncJoinEvent += MatrixClient_OnEvent;
+        Api.SyncInviteEvent += MatrixClient_OnInvite;
+      }
+      catch (MatrixException e)
+      {
+        throw new MatrixException("An exception occured while trying to connect", e);
+      }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Matrix.Client.MatrixClient"/> class.
+    /// This intended for Application Services only who want to preform actions as another user.
+    /// Sync is not preformed.
+    /// </summary>
+    /// <param name="URL">URL before /_matrix/</param>
+    /// <param name="application_token">Application token for the AS.</param>
+    /// <param name="userid">Userid as the user you intend to go as.</param>
+    public MatrixClient(string URL, string application_token, string userid)
+    {
+      Api = new MatrixAPI(URL, application_token, userid);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Matrix.Client.MatrixClient"/> class for testing.
+    /// </summary>
+    public MatrixClient(MatrixAPI api)
+    {
+      this.Api = api;
+      api.SyncJoinEvent += MatrixClient_OnEvent;
+      api.SyncInviteEvent += MatrixClient_OnInvite;
+    }
+
+    /// <summary>
+    /// Gets the sync token from the API.
+    /// </summary>
+    /// <returns>The sync token.</returns>
+    public string GetSyncToken()
+    {
+      return Api.GetSyncToken();
+    }
+
+    /// <summary>
+    /// Gets the access token from the API.
+    /// </summary>
+    /// <returns>The access token.</returns>
+    public string GetAccessToken()
+    {
+      return Api.GetAccessToken();
+    }
+
+    public MatrixLoginResponse GetCurrentLogin()
+    {
+      return Api.GetCurrentLogin();
+    }
+
+    private void MatrixClient_OnInvite(string roomid, MatrixEventRoomInvited joined)
+    {
+      if (OnInvite != null)
+      {
+        OnInvite.Invoke(roomid, joined);
+      }
+    }
+
+    private void MatrixClient_OnEvent(string roomid, MatrixEventRoomJoined joined)
+    {
+      MatrixRoom mroom;
+      if (!_rooms.ContainsKey(roomid))
+      {
+        mroom = new MatrixRoom(Api, roomid);
+        _rooms.TryAdd(roomid, mroom);
+        //Update existing room
+      }
+      else
+      {
+        mroom = _rooms[roomid];
+      }
+      joined.state.events.ToList().ForEach(x => { mroom.FeedEvent(x); });
+      joined.timeline.events.ToList().ForEach(x => { mroom.FeedEvent(x); });
+      mroom.SetEphemeral(joined.ephemeral);
+    }
+
+    /// <summary>
+    /// Login with a given username and password.
+    /// Currently, this is the only login method the SDK supports.
+    /// </summary>
+    /// <param name="username">Username</param>
+    /// <param name="password">Password</param>
+    public MatrixLoginResponse LoginWithPassword(string username, string password, string device_id = null)
+    {
+      var result = Api.ClientLogin(new MatrixLoginPassword(username, password, device_id));
+      Api.SetLogin(result);
+      return result;
+    }
+
+    /// <param name="syncToken"> If you stored the sync token before, you can set it for the API here</param>
+    public void StartSync(string syncToken = "")
+    {
+      Api.SetSyncToken(syncToken);
+      Api.ClientSync();
+      Api.StartSyncThreads();
+    }
+
+    /// <summary>
+    /// Login with a given username and token.
+    /// This method will also start a sync with the server
+    /// Currently, this is the only login method the SDK supports.
+    /// </summary>
+    /// <param name="username">Username</param>
+    /// <param name="token">Access Token</param>
+    public void LoginWithToken(string username, string token)
+    {
+      Api.ClientLogin(new MatrixLoginToken(username, token));
+      Api.ClientSync();
+      Api.StartSyncThreads();
+    }
+
+    /// <summary>
+    /// Use existing login information when connecting to Matrix.
+    /// </summary>
+    /// <param name="user_id">Full Matrix user id.</param>
+    /// <param name="access_token">Access token.</param>
+    /// <param name="refresh_token">Refresh token.</param>
+    public void UseExistingToken(string user_id, string access_token)
+    {
+      Api.SetLogin(new MatrixLoginResponse
+      {
+        user_id = user_id,
+        access_token = access_token,
+        home_server = Api.BaseURL
+      });
+    }
+
+
+    /// <summary>
+    /// Get information about a user from the server.
+    /// </summary>
+    /// <returns>A MatrixUser object</returns>
+    /// <param name="userid">User ID</param>
+    public MatrixUser GetUser(string userid = null)
+    {
+      userid = userid == null ? Api.UserId : userid;
+      MatrixProfile profile = Api.ClientProfile(userid);
+      if (profile != null)
+      {
+        return new MatrixUser(profile, userid);
+      }
+      return null;
+    }
+
+    public void SetDisplayName(string displayname)
+    {
+      Api.ClientSetDisplayName(Api.UserId, displayname);
+    }
+
+    public void SetAvatar(string avatar)
+    {
+      Api.ClientSetAvatar(Api.UserId, avatar);
+    }
+
+    /// <summary>
+    /// Get all the Rooms that the user has joined.
+    /// </summary>
+    /// <returns>Array of MatrixRooms</returns>
+    public MatrixRoom[] GetAllRooms()
+    {
+      return _rooms.Values.ToArray();
+    }
+
+    /// <summary>
+    /// Creates a new room with the specified details, or a blank one otherwise.
+    /// </summary>
+    /// <returns>A MatrixRoom object</returns>
+    /// <param name="roomdetails">Optional set of options to send to the server.</param>
+    public MatrixRoom CreateRoom(MatrixCreateRoom roomdetails = null)
+    {
+      string roomid = Api.ClientCreateRoom(roomdetails);
+      if (roomid != null)
+      {
+        MatrixRoom room = JoinRoom(roomid);
+        return room;
+      }
+      return null;
+    }
+
+    /// <summary>
+    /// Alias for <see cref="Matrix.MatrixClient.CreateRoom"/> which lets you set common items before creation.
+    /// </summary>
+    /// <returns>A MatrixRoom object</returns>
+    /// <param name="name">The room name.</param>
+    /// <param name="alias">The primary alias</param>
+    /// <param name="topic">The room topic</param>
+    public MatrixRoom CreateRoom(string name, string alias = null, string topic = null)
+    {
+      MatrixCreateRoom room = new MatrixCreateRoom();
+      room.name = name;
+      room.room_alias_name = alias;
+      room.topic = topic;
+      return CreateRoom(room);
+    }
+
+    /// <summary>
+    /// Join a matrix room. If the user has already joined this room, do nothing.
+    /// </summary>
+    /// <returns>The room.</returns>
+    /// <param name="roomid">roomid or alias</param>
+    public MatrixRoom JoinRoom(string roomid)
+    {//TODO: Maybe add a try method.
+      if (!_rooms.ContainsKey(roomid))
+      {//TODO: Check the status of the room too.
+        roomid = Api.ClientJoin(roomid);
+        if (roomid == null)
+        {
+          return null;
+        }
+        MatrixRoom room = new MatrixRoom(Api, roomid);
+        _rooms.TryAdd(room.ID, room);
+      }
+      return _rooms[roomid];
+    }
+
+    public MatrixMediaFile UploadFile(string contentType, byte[] data)
+    {
+      string url = Api.MediaUpload(contentType, data);
+      return new MatrixMediaFile(Api, url, contentType);
+    }
+
+    /// <summary>
+    /// Return a joined room object by it's roomid.
+    /// </summary>
+    /// <returns>The room.</returns>
+    /// <param name="roomid">Roomid.</param>
+    public MatrixRoom GetRoom(string roomid)
+    {//TODO: Maybe add a try method.
+      MatrixRoom room = null;
+      _rooms.TryGetValue(roomid, out room);
+      if (room == null)
+      {
+        log.LogInformation($"Don't have {roomid} synced, getting the room from /state");
+        // If we don't have the room, attempt to grab it's state.
+        var state = Api.GetRoomState(roomid);
+        room = new MatrixRoom(Api, roomid);
+        foreach (var matrixEvent in state)
+        {
+          room.FeedEvent(matrixEvent);
+        }
+        _rooms.TryAdd(roomid, room);
+      }
+      return room;
+    }
+    /// <summary>
+    /// Get a room object by any of it's registered aliases.
+    /// </summary>
+    /// <returns>The room by alias.</returns>
+    /// <param name="alias">CanonicalAlias or any Alias</param>
+    public MatrixRoom GetRoomByAlias(string alias)
+    {
+      MatrixRoom room = _rooms.Values.FirstOrDefault(x =>
+      {
+        if (x.CanonicalAlias == alias)
+        {
+          return true;
+        }
+
+        if (x.Aliases != null)
+        {
+          return x.Aliases.Contains(alias);
+        }
+        return false;
+      });
+      if (room != default(MatrixRoom))
+      {
+        return room;
+      }
+
+      return null;
+    }
+
+    /// <summary>
+    /// Add a new type of message to be decoded during sync operations.
+    /// </summary>
+    /// <param name="msgtype">msgtype.</param>
+    /// <param name="type">Type that inheritis MatrixMRoomMessage</param>
+    public void AddRoomMessageType(string msgtype, Type type)
+    {
+      Api.AddMessageType(msgtype, type);
+    }
+
+    /// <summary>
+    /// Add a new type of state event to be decoded during sync operations.
+    /// </summary>
+    /// <param name="msgtype">msgtype.</param>
+    /// <param name="type">Type that inheritis MatrixMRoomMessage</param>
+    public void AddStateEventType(string msgtype, Type type)
+    {
+      Api.AddEventType(msgtype, type);
+    }
+
+    public PublicRooms GetPublicRooms(int limit = 0, string since = "", string server = "")
+    {
+      return Api.PublicRooms(limit, since, server);
+    }
+
+    public void DeleteFromRoomDirectory(string alias)
+    {
+      Api.DeleteFromRoomDirectory(alias);
+    }
+
+    /// <summary>
+    /// Releases all resource used by the <see cref="Matrix.Client.MatrixClient"/> object.
+    /// In addition, this will stop the sync thread.
+    /// </summary>
+    /// <remarks>Call <see cref="Dispose"/> when you are finished using the <see cref="Matrix.Client.MatrixClient"/>. The
+    /// <see cref="Dispose"/> method leaves the <see cref="Matrix.Client.MatrixClient"/> in an unusable state. After
+    /// calling <see cref="Dispose"/>, you must release all references to the <see cref="Matrix.Client.MatrixClient"/>
+    /// so the garbage collector can reclaim the memory that the <see cref="Matrix.Client.MatrixClient"/> was occupying.</remarks>
+    public void Dispose()
+    {
+      Api.StopSyncThreads();
+    }
+  }
 }

--- a/Matrix/MatrixAPI.cs
+++ b/Matrix/MatrixAPI.cs
@@ -18,252 +18,275 @@ using Newtonsoft.Json.Linq;
 
 namespace Matrix
 {
-    public delegate void MatrixAPIRoomJoinedDelegate(string roomid, MatrixEventRoomJoined joined);
-    public delegate void MatrixAPIRoomInviteDelegate(string roomid, MatrixEventRoomInvited invited);
-	// We need to mock MatrixAPI, hence needing virtuals.
-	// ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
-	public partial class MatrixAPI
-	{
-		public event MatrixAPIRoomJoinedDelegate SyncJoinEvent;
-		public event MatrixAPIRoomInviteDelegate SyncInviteEvent;
-		
-		public bool IsConnected { get; private set; }
-		public virtual bool RunningInitialSync { get; private set; } = true;
-		public virtual string BaseURL  { get; private set; }
-		public int BadSyncTimeout { get; set; } = 25000;
-		public virtual string UserId {get; set;}
+  public delegate void MatrixAPIRoomJoinedDelegate(string roomid, MatrixEventRoomJoined joined);
+  public delegate void MatrixAPIRoomInviteDelegate(string roomid, MatrixEventRoomInvited invited);
+  // We need to mock MatrixAPI, hence needing virtuals.
+  // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
+  public partial class MatrixAPI
+  {
+    public event MatrixAPIRoomJoinedDelegate SyncJoinEvent;
+    public event MatrixAPIRoomInviteDelegate SyncInviteEvent;
 
-		private MatrixVersions versions;
-		private string syncToken = "";
-		private ILogger log = Logger.Factory.CreateLogger<MatrixAPI>();
-		private bool IsAS;
-		private MatrixLoginResponse current_login;
-		private Thread poll_thread;
-		private bool shouldRun;
-		private Random rng;
-		private JSONEventConverter event_converter;
-		private IMatrixAPIBackend mbackend;
-		
-		static readonly JSONSerializer matrixSerializer = new JSONSerializer ();
+    public bool IsConnected { get; private set; }
+    public virtual bool RunningInitialSync { get; private set; } = true;
+    public virtual string BaseURL { get; private set; }
+    public int BadSyncTimeout { get; set; } = 25000;
+    public virtual string UserId { get; set; }
 
-		/// <summary>
-		/// Timeout in seconds between sync requests.
-		/// </summary>
-		public int SyncTimeout {get;set;} = 10000;
+    private MatrixVersions versions;
+    private string syncToken = "";
+    private ILogger log = Logger.Factory.CreateLogger<MatrixAPI>();
+    private bool IsAS;
+    private MatrixLoginResponse current_login;
+    private Thread poll_thread;
+    private bool shouldRun;
+    private Random rng;
+    private JSONEventConverter event_converter;
+    private IMatrixAPIBackend mbackend;
 
-		public MatrixAPI (string URL)
-		{
-			if (!Uri.IsWellFormedUriString (URL, UriKind.Absolute)) {
-				throw new MatrixException ("URL is not valid");
-			}
+    static readonly JSONSerializer matrixSerializer = new JSONSerializer();
 
-			IsAS = false;
-			mbackend = new HttpBackend (URL);
-			BaseURL = URL;
-			rng = new Random (DateTime.Now.Millisecond);
-			event_converter = new JSONEventConverter ();
-		}
+    /// <summary>
+    /// Timeout in seconds between sync requests.
+    /// </summary>
+    public int SyncTimeout { get; set; } = 10000;
 
-		public MatrixAPI(string URL, string application_token, string user_id){
-			if (!Uri.IsWellFormedUriString (URL, UriKind.Absolute)) {
-				throw new MatrixException("URL is not valid");
-			}
+    public MatrixAPI(string URL, System.Net.Http.HttpClientHandler handler = null)
+    {
+      if (!Uri.IsWellFormedUriString(URL, UriKind.Absolute))
+      {
+        throw new MatrixException("URL is not valid");
+      }
+      IsAS = false;
+      mbackend = new HttpBackend(URL, handler: handler);
+      BaseURL = URL;
+      rng = new Random(DateTime.Now.Millisecond);
+      event_converter = new JSONEventConverter();
+    }
 
-			IsAS = true;
-			mbackend = new HttpBackend (URL,user_id);
-			mbackend.SetAccessToken(application_token);
-			UserId = user_id;
-			BaseURL = URL;
-			rng = new Random (DateTime.Now.Millisecond);
-			event_converter = new JSONEventConverter ();
-		}
+    public MatrixAPI(string URL, string application_token, string user_id)
+    {
+      if (!Uri.IsWellFormedUriString(URL, UriKind.Absolute))
+      {
+        throw new MatrixException("URL is not valid");
+      }
 
-		public MatrixAPI (string URL, IMatrixAPIBackend backend)
-		{
-			if (!Uri.IsWellFormedUriString (URL, UriKind.Absolute)) {
-				throw new MatrixException("URL is not valid");
-			}
+      IsAS = true;
+      mbackend = new HttpBackend(URL, user_id);
+      mbackend.SetAccessToken(application_token);
+      UserId = user_id;
+      BaseURL = URL;
+      rng = new Random(DateTime.Now.Millisecond);
+      event_converter = new JSONEventConverter();
+    }
 
-			IsAS = true;
-			mbackend = backend;
-			BaseURL = URL;
-			rng = new Random (DateTime.Now.Millisecond);
-			event_converter = new JSONEventConverter ();
-		}
+    public MatrixAPI(string URL, IMatrixAPIBackend backend)
+    {
+      if (!Uri.IsWellFormedUriString(URL, UriKind.Absolute))
+      {
+        throw new MatrixException("URL is not valid");
+      }
+
+      IsAS = true;
+      mbackend = backend;
+      BaseURL = URL;
+      rng = new Random(DateTime.Now.Millisecond);
+      event_converter = new JSONEventConverter();
+    }
 
 
-		public void AddMessageType (string name, Type type)
-		{
-			event_converter.AddMessageType(name,type);
-		}
+    public void AddMessageType(string name, Type type)
+    {
+      event_converter.AddMessageType(name, type);
+    }
 
-		public void AddEventType (string msgtype, Type type)
-		{
-			event_converter.AddEventType(msgtype, type);
-		}
+    public void AddEventType(string msgtype, Type type)
+    {
+      event_converter.AddEventType(msgtype, type);
+    }
 
-		private void pollThread_Run(){
-			while (shouldRun) {
-				try
-				{
-					ClientSync (true);
-				}
-				catch(Exception e){
-					#if DEBUG
-					Console.WriteLine ("[warn] A Matrix exception occured during sync!");
-					Console.WriteLine (e);
-					#endif
-				}
-				Thread.Sleep(250);
-			}
-		}
+    private void pollThread_Run()
+    {
+      while (shouldRun)
+      {
+        try
+        {
+          ClientSync(true);
+        }
+        catch (Exception e)
+        {
+#if DEBUG
+          Console.WriteLine("[warn] A Matrix exception occured during sync!");
+          Console.WriteLine(e);
+#endif
+        }
+        Thread.Sleep(250);
+      }
+    }
 
-		public void SetSyncToken(string synctoken){
-			syncToken = synctoken;
-			RunningInitialSync = false;
-		}
+    public void SetSyncToken(string synctoken)
+    {
+      syncToken = synctoken;
+      RunningInitialSync = false;
+    }
 
-		public virtual string GetSyncToken(){
-			return syncToken;
-		}
+    public virtual string GetSyncToken()
+    {
+      return syncToken;
+    }
 
-		public virtual string GetAccessToken ()
-		{
-			if (current_login != null) {
-				return current_login.access_token;
-			}
+    public virtual string GetAccessToken()
+    {
+      if (current_login != null)
+      {
+        return current_login.access_token;
+      }
 
-			return null;
-		}
+      return null;
+    }
 
-		public virtual MatrixLoginResponse GetCurrentLogin ()
-		{
-			return current_login;
-		}
+    public virtual MatrixLoginResponse GetCurrentLogin()
+    {
+      return current_login;
+    }
 
-		public void SetLogin(MatrixLoginResponse response){
-			current_login = response;
-			UserId = response.user_id;
-			mbackend.SetAccessToken(response.access_token);
-		}
+    public void SetLogin(MatrixLoginResponse response)
+    {
+      current_login = response;
+      UserId = response.user_id;
+      mbackend.SetAccessToken(response.access_token);
+    }
 
-		public static JObject ObjectToJson (object data)
-		{
-			JObject container;
-			using (JTokenWriter writer = new JTokenWriter ()) {
-				try {
-					matrixSerializer.Serialize (writer, data);
-					container = (JObject)writer.Token;
-				} catch (Exception e) {
-					throw new Exception("Couldn't convert obj to JSON",e);
-				}
-			}
-			return container;
-		}
+    public static JObject ObjectToJson(object data)
+    {
+      JObject container;
+      using (JTokenWriter writer = new JTokenWriter())
+      {
+        try
+        {
+          matrixSerializer.Serialize(writer, data);
+          container = (JObject)writer.Token;
+        }
+        catch (Exception e)
+        {
+          throw new Exception("Couldn't convert obj to JSON", e);
+        }
+      }
+      return container;
+    }
 
-		public bool IsLoggedIn(){
-			//TODO: Check token is still valid
-			return current_login != null;
-		}
+    public bool IsLoggedIn()
+    {
+      //TODO: Check token is still valid
+      return current_login != null;
+    }
 
-		private void ProcessSync(MatrixSync syncData){
-			//Grab data from rooms the user has joined.
-			foreach (KeyValuePair<string,MatrixEventRoomJoined> room in syncData.rooms.join)
-			{
-				SyncJoinEvent?.Invoke (room.Key, room.Value);
-			}
-            foreach (KeyValuePair<string,MatrixEventRoomInvited> room in syncData.rooms.invite)
-            {
-	            SyncInviteEvent?.Invoke (room.Key, room.Value);
-            }
-			syncToken = syncData.next_batch;
-		}
+    private void ProcessSync(MatrixSync syncData)
+    {
+      //Grab data from rooms the user has joined.
+      foreach (KeyValuePair<string, MatrixEventRoomJoined> room in syncData.rooms.join)
+      {
+        SyncJoinEvent?.Invoke(room.Key, room.Value);
+      }
+      foreach (KeyValuePair<string, MatrixEventRoomInvited> room in syncData.rooms.invite)
+      {
+        SyncInviteEvent?.Invoke(room.Key, room.Value);
+      }
+      syncToken = syncData.next_batch;
+    }
 
-		[MatrixSpec(EMatrixSpecApiVersion.R001, EMatrixSpecApi.ClientServer, "get-matrix-client-versions")]
-		public MatrixVersions ClientVersions(){
-			MatrixRequestError error = mbackend.Get ("/_matrix/client/versions",false, out var result);
-			if (error.IsOk)
-			{
-				var res = result.ToObject<MatrixVersions>();
-				versions = res;
-				return res;
-			}
+    [MatrixSpec(EMatrixSpecApiVersion.R001, EMatrixSpecApi.ClientServer, "get-matrix-client-versions")]
+    public MatrixVersions ClientVersions()
+    {
+      MatrixRequestError error = mbackend.Get("/_matrix/client/versions", false, out var result);
+      if (error.IsOk)
+      {
+        var res = result.ToObject<MatrixVersions>();
+        versions = res;
+        return res;
+      }
 
-			throw new MatrixException (error.ToString());//TODO: Need a better exception
-		}
+      throw new MatrixException(error.ToString());//TODO: Need a better exception
+    }
 
-		[MatrixSpec(EMatrixSpecApiVersion.R040, EMatrixSpecApi.ClientServer,
-			"get-matrix-client-r0-joined_rooms")]
-		public List<string> GetJoinedRooms()
-		{
-			MatrixRequestError error = mbackend.Get("/_matrix/client/r0/joined_rooms", true, out var result);
-			if (!error.IsOk) {
-				throw new MatrixException (error.ToString());
-			}
-			return (result as JObject)?.GetValue("joined_rooms").ToObject<List<string>>();
-		}
-		
-		[MatrixSpec(EMatrixSpecApiVersion.R040, EMatrixSpecApi.ClientServer,
-			"get-matrix-client-r0-joined_members")]
-		public Dictionary<string, MatrixProfile> GetJoinedMembers(string roomId)
-		{
-			MatrixRequestError error = mbackend.Get($"/_matrix/client/r0/rooms/{roomId}/joined_members", true, out var result);
-			if (!error.IsOk) {
-				throw new MatrixException (error.ToString());
-			}
-			return (result as JObject)?.GetValue("joined").ToObject<Dictionary<string, MatrixProfile>>();
-		}
+    [MatrixSpec(EMatrixSpecApiVersion.R040, EMatrixSpecApi.ClientServer,
+      "get-matrix-client-r0-joined_rooms")]
+    public List<string> GetJoinedRooms()
+    {
+      MatrixRequestError error = mbackend.Get("/_matrix/client/r0/joined_rooms", true, out var result);
+      if (!error.IsOk)
+      {
+        throw new MatrixException(error.ToString());
+      }
+      return (result as JObject)?.GetValue("joined_rooms").ToObject<List<string>>();
+    }
 
-		public void RegisterUserAsAS (string user)
-		{
-			if(!IsAS){
-				throw new MatrixException("This client is not registered as a application service client. You can't create new appservice users");
-			}
-			JObject request = JObject.FromObject( new {
-				type = "m.login.application_service",
-				user
-			});
+    [MatrixSpec(EMatrixSpecApiVersion.R040, EMatrixSpecApi.ClientServer,
+      "get-matrix-client-r0-joined_members")]
+    public Dictionary<string, MatrixProfile> GetJoinedMembers(string roomId)
+    {
+      MatrixRequestError error = mbackend.Get($"/_matrix/client/r0/rooms/{roomId}/joined_members", true, out var result);
+      if (!error.IsOk)
+      {
+        throw new MatrixException(error.ToString());
+      }
+      return (result as JObject)?.GetValue("joined").ToObject<Dictionary<string, MatrixProfile>>();
+    }
 
-			MatrixRequestError error = mbackend.Post("/_matrix/client/r0/register",true,request,out var result);
-			if (!error.IsOk) {
-				throw new MatrixException (error.ToString());//TODO: Need a better exception
-			}
-		}
+    public void RegisterUserAsAS(string user)
+    {
+      if (!IsAS)
+      {
+        throw new MatrixException("This client is not registered as a application service client. You can't create new appservice users");
+      }
+      JObject request = JObject.FromObject(new
+      {
+        type = "m.login.application_service",
+        user
+      });
 
-		public void ThrowIfNotSupported([CallerMemberName] string name = null)
-		{
-			if (name == null)
-			{
-				return;
-			}
-			if (versions == null)
-			{
-				ClientVersions();
-			}
-			MatrixSpec spec = typeof(MatrixAPI).GetMethod(name).GetCustomAttribute(typeof(MatrixSpec)) as MatrixSpec;
-			if (spec == null)
-			{
-				#if DEBUG
-				log.LogWarning($"{name} has no MatrixSpec attribute, cannot determine homeserver support");
-				#endif
-				return;
-			}
-			// Ensure we support a version of the spec >= the min version and <= the last version.
-			if (!versions.supportedVersions().Any(
-				version => version >= spec.MinVersion && version <= spec.LastVersion)
-			)
-			{
-				return;
-			}
-			string msg = "This homeserver doesn't support this endpoint.";
-			if (spec.LastVersion != EMatrixSpecApiVersion.Unknown)
-			{
-				msg += $"The endpoint was removed in spec version {MatrixSpec.GetStringForVersion(spec.LastVersion)}";
-			} else
-			{
-				msg += $"The endpoint was added in spec version {MatrixSpec.GetStringForVersion(spec.MinVersion)}";
-			}
-			throw new MatrixException(msg);
-		}
-	}
+      MatrixRequestError error = mbackend.Post("/_matrix/client/r0/register", true, request, out var result);
+      if (!error.IsOk)
+      {
+        throw new MatrixException(error.ToString());//TODO: Need a better exception
+      }
+    }
+
+    public void ThrowIfNotSupported([CallerMemberName] string name = null)
+    {
+      if (name == null)
+      {
+        return;
+      }
+      if (versions == null)
+      {
+        ClientVersions();
+      }
+      MatrixSpec spec = typeof(MatrixAPI).GetMethod(name).GetCustomAttribute(typeof(MatrixSpec)) as MatrixSpec;
+      if (spec == null)
+      {
+#if DEBUG
+        log.LogWarning($"{name} has no MatrixSpec attribute, cannot determine homeserver support");
+#endif
+        return;
+      }
+      // Ensure we support a version of the spec >= the min version and <= the last version.
+      if (!versions.supportedVersions().Any(
+        version => version >= spec.MinVersion && version <= spec.LastVersion)
+      )
+      {
+        return;
+      }
+      string msg = "This homeserver doesn't support this endpoint.";
+      if (spec.LastVersion != EMatrixSpecApiVersion.Unknown)
+      {
+        msg += $"The endpoint was removed in spec version {MatrixSpec.GetStringForVersion(spec.LastVersion)}";
+      }
+      else
+      {
+        msg += $"The endpoint was added in spec version {MatrixSpec.GetStringForVersion(spec.MinVersion)}";
+      }
+      throw new MatrixException(msg);
+    }
+  }
 }


### PR DESCRIPTION
I added an optional HttpClientHandler parameter to several constructors in order to set a custom HttpClientHandler for the HttpClient in the HttpBackend.

var cert = new X509Certificate2("certifcate.pfx", "password");
var handler = new System.Net.Http.HttpClientHandler();
handler.ClientCertificates.Add(cert);

var client = new MatrixClient("localhost:8008", handler);
